### PR TITLE
fix: remix imports

### DIFF
--- a/contracts/DataFeedReader.sol
+++ b/contracts/DataFeedReader.sol
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.17;
 
-import "@openzeppelin/contracts/access/Ownable.sol";
-import "@api3/contracts/v0.8/interfaces/IProxy.sol";
+import "@openzeppelin/contracts@4.9.5/access/Ownable.sol";
+import "@api3/airnode-protocol-v1/contracts/api3-server-v1/proxies/interfaces/IProxy.sol";
 
 contract DataFeedReaderExample is Ownable {
     // The proxy contract address obtained from the API3 Market UI.

--- a/contracts/DataFeedReader.sol
+++ b/contracts/DataFeedReader.sol
@@ -2,7 +2,7 @@
 pragma solidity 0.8.17;
 
 import "@openzeppelin/contracts@4.9.5/access/Ownable.sol";
-import "@api3/airnode-protocol-v1/contracts/api3-server-v1/proxies/interfaces/IProxy.sol";
+import "@api3/contracts/v0.8/interfaces/IProxy.sol";
 
 contract DataFeedReaderExample is Ownable {
     // The proxy contract address obtained from the API3 Market UI.

--- a/contracts/QrngRequesterUpdated.sol
+++ b/contracts/QrngRequesterUpdated.sol
@@ -1,7 +1,8 @@
 //SPDX-License-Identifier: MIT
 pragma solidity 0.8.9;
+
 import "@api3/airnode-protocol/contracts/rrp/requesters/RrpRequesterV0.sol";
-import "@openzeppelin/contracts/access/Ownable.sol";
+import "@openzeppelin/contracts@4.9.5/access/Ownable.sol";
 
 /// @title Example contract that uses Airnode RRP to access QRNG services
 contract QrngExample is RrpRequesterV0, Ownable {

--- a/contracts/RequesterWithWithdrawal.sol
+++ b/contracts/RequesterWithWithdrawal.sol
@@ -2,7 +2,7 @@
 pragma solidity 0.8.9;
 
 import "@api3/airnode-protocol/contracts/rrp/requesters/RrpRequesterV0.sol";
-import "@openzeppelin/contracts/access/Ownable.sol";
+import "@openzeppelin/contracts@4.9.5/access/Ownable.sol";
 
 // A Requester that will return the requested data by calling the specified Airnode.
 contract Requester is RrpRequesterV0, Ownable {


### PR DESCRIPTION
Fixed imports causing the contracts to not compile on Remix IDE.
- `@openzeppelin/contracts` to `v4.9.5`
- `@api3/contracts` to `@api3/airnode-protocol-v1`